### PR TITLE
对arr[l...r]的区间排序错误修改

### DIFF
--- a/03-Sorting-Advance/Course Code (Java)/03-Merge-Sort-Advance/src/bobo/algo/InsertionSort.java
+++ b/03-Sorting-Advance/Course Code (Java)/03-Merge-Sort-Advance/src/bobo/algo/InsertionSort.java
@@ -28,7 +28,7 @@ public class InsertionSort{
         for( int i = l + 1 ; i <= r ; i ++ ){
             Comparable e = arr[i];
             int j = i;
-            for( ; j > 0 && arr[j-1].compareTo(e) > 0 ; j--)
+            for( ; j > l && arr[j-1].compareTo(e) > 0 ; j--)
                 arr[j] = arr[j-1];
             arr[j] = e;
         }


### PR DESCRIPTION
对arr[l...r]的区间的插入排序，子循环的终止条件有误，不应在0而应在左边界l。